### PR TITLE
[BUGFIX] Allow clipboard APIs on HTTP

### DIFF
--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers.php
@@ -213,7 +213,28 @@ events.push(function() {
 
 	$('.pubkey').click(function () {
 
-		navigator.clipboard.writeText($(this).attr('title'));
+		var publicKey = $(this).attr('title');
+
+		try {
+			// The 'modern' way...
+			navigator.clipboard.writeText(publicKey);
+		} catch {
+			console.warn("Failed to copy text using navigator.clipboard, falling back to commands");
+
+			// Convert the TD contents to an input with pub key
+			var pubKeyInput = $('<input/>', {val: publicKey});
+			var oldText = $(this).text();
+
+			// Add to DOM
+			$(this).html(pubKeyInput);
+
+			// copy
+			pubKeyInput.select();
+			document.execCommand("copy");
+
+			// revert back to just text
+			$(this).html(oldText);
+		}
 
 	});
 

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
@@ -268,7 +268,28 @@ endif;
 events.push(function() {
 	$('.pubkey').click(function () {
 
-		navigator.clipboard.writeText($(this).attr('title'));
+		var publicKey = $(this).attr('title');
+
+		try {
+			// The 'modern' way...
+			navigator.clipboard.writeText(publicKey);
+		} catch {
+			console.warn("Failed to copy text using navigator.clipboard, falling back to commands");
+
+			// Convert the TD contents to an input with pub key
+			var pubKeyInput = $('<input/>', {val: publicKey});
+			var oldText = $(this).text();
+
+			// Add to DOM
+			$(this).html(pubKeyInput);
+
+			// copy
+			pubKeyInput.select();
+			document.execCommand("copy");
+
+			// revert back to just text
+			$(this).html(oldText);
+		}
 
 	});
 

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels_edit.php
@@ -549,9 +549,15 @@ events.push(function() {
 
 		var originalText = $this.text();
 
-		// The 'modern' way...
-		navigator.clipboard.writeText($('#publickey').val());
-		
+		try {
+			// The 'modern' way...
+			navigator.clipboard.writeText($('#publickey').val());
+		} catch {
+			console.warn("Failed to copy text using navigator.clipboard, falling back to commands");
+			$('#publickey').select();
+			document.execCommand("copy");
+		}
+
 		$this.text($this.attr('data-success-text'));
 
 		setTimeout(function() {


### PR DESCRIPTION
Resolves redmine ticket: [12258](https://redmine.pfsense.org/issues/12258)

Added more JS logic to allow for browsers who wont allow access to navigator.clipboard API to still copy public keys for tunnels, peers list and tunnel edit.

Works on HTTP admin access as a fallback, still attempts the modern API first