### PR TITLE
[BUGFIX] Keepalive validation and allowing 0 value

### DIFF
--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/classes/wgconfig.class.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/classes/wgconfig.class.php
@@ -390,9 +390,17 @@ class wgconfig {
 
 		$line_found = false;
 
+		$value_is_valid = !empty($value);
+
+		// Keepalive can have a valid value of "0" (disabled) which empty() above will mark as false.
+		// So mark it as valid for this case
+		if ($attr == "PersistentKeepalive" && $value == "0") {
+			$value_is_valid = true;
+		}
+
 		// Check if the section is valid and if the desired attribute value is valid...
 		if (([self::SECTION_FIRSTLINE => $section_firstline, self::SECTION_LASTLINE => $section_lastline] = $this->_get_section_range($key))
-		    && (!empty($value))) {
+		    && ($value_is_valid)) {
 
 			foreach (range($section_firstline + 1, $section_lastline + 1) as $i) {
 

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_validate.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_validate.inc
@@ -175,8 +175,15 @@ function wg_validate_peer_post($pconfig, $posted_peer_idx) {
 	// Check persistent keep alive
 	$keepalive = $pconfig['persistentkeepalive'];
 
-	if (!empty($keepalive) && !is_numericint($keepalive)) {
-		$input_errors[] = "Invalid keep alive interval ({$keepalive}).";
+	// If user provided something, validate it. Empty is a valid option.
+	if (!empty($keepalive)) {
+		// Generic is it a number check
+		if (!is_numericint($keepalive)) {
+			$input_errors[] = "Invalid keep alive interval ({$keepalive}).";
+		// Valid range check on a number for a 16 bit integer
+		} else if (intval($keepalive) < 0 || intval($keepalive) > 65535) {
+			$input_errors[] = "Keep alive interval must be in range 0-65535 ({$keepalive}).";
+		}
 	}
 
 	// Check public key


### PR DESCRIPTION
This PR resolves redmine issue [12251](https://redmine.pfsense.org/issues/12251).

It does so in two parts:
 - Validate the user provided keepalive to check for 16 bit uint value (0-65535)
 - Allow the WG Config class to write out the default value of "0" to a config

Now a user will be informed and a bad value rejected if not within 0-65535, and the default value of 0 is now actually written out to the configs.