### PR TITLE
fix for https://redmine.pfsense.org/issues/13153

### DIFF
--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_service.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_service.inc
@@ -321,6 +321,9 @@ function wg_restart_extra_services($force = false) {
 	// unbound
 	services_unbound_configure();
 
+	// reconfigure static routes
+	system_staticroutes_configure();
+
 	// TODO: This is where we will add facilities for users to pick what services to restart
 
 	return true;


### PR DESCRIPTION
After downing & upping WG site to site tunnels, or stopping / restarting the service, any static routes are lost and the tunnels break if you're not using FRR/BGP etc.

This adds a call to `system_staticroutes_configure()` in `wg_service.inc` so the routes get re-added. I tested this on 22.05.b.20220512.0600 with 2 S2S tunnels and a RemoteAccess tunnel.

see [https://redmine.pfsense.org/issues/13153](https://redmine.pfsense.org/issues/13153)